### PR TITLE
add support for Object Workshop and also other additions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,20 +12,12 @@ set(CMAKE_CXX_VISIBILITY_PRESET hidden)
 
 project(CommentEmojis VERSION 1.0.0)
 
-add_library(${PROJECT_NAME} SHARED
-    src/main.cpp
-    src/EmojiLoader.cpp
-    src/CCLabelBMFontExt.cpp
-    src/TextAreaExt.cpp
-    src/CCProxyNode.cpp
-    src/EmojiPickPopup.cpp
-    src/Hooks/GlobedChatCell.cpp
-    src/Hooks/GlobedChatListPopup.cpp
-    src/Hooks/CommentCell.cpp
-    src/Hooks/ShareCommentLayer.cpp
-    src/EmojiNode.cpp
-    # Add your cpp files here
+file(GLOB SOURCES
+	src/*.cpp
+    src/Hooks/*.cpp
 )
+
+add_library(${PROJECT_NAME} SHARED ${SOURCES})
 
 if (NOT DEFINED ENV{GEODE_SDK})
     message(FATAL_ERROR "Unable to find Geode SDK! Please define GEODE_SDK environment variable to point to Geode")

--- a/mod.json
+++ b/mod.json
@@ -1,21 +1,21 @@
 {
-	"geode": "3.4.0",
-	"version": "v1.1.0",
+	"geode": "3.7.1",
+	"version": "v1.1.1",
 	"gd": {
 		"win": "2.206",
-        "mac": "2.206",
-		"android": "*",
+		"mac": "2.206",
+		"android": "2.206",
 		"ios": "2.206"
 	},
 	"id": "thesillydoggo.comment_emojis",
 	"name": "Emojis in Comments",
 	"dependencies": [
-        {
-            "id": "geode.node-ids",
-            "version": ">=1.12.0-beta.2",
-            "importance": "required"
-        }
-    ],
+		{
+			"id": "geode.node-ids",
+			"version": ">=1.12.0-beta.2",
+			"importance": "required"
+		}
+	],
 	"resources": {
 		"spritesheets": {
 			"GJ_EmojiSheet": [
@@ -51,5 +51,8 @@
 	},
 	"developer": "TheSillyDoggo",
 	"description": "Allows you to post emojis in the comments of levels (and on account posts)",
-	"repository": "https://github.com/TheSillyDoggo/Comment-Emojis"
+	"repository": "https://github.com/TheSillyDoggo/Comment-Emojis",
+    "links": {
+		"source": "https://github.com/TheSillyDoggo/Comment-Emojis"
+    }
 }

--- a/src/Hooks/OWCommentCell.cpp
+++ b/src/Hooks/OWCommentCell.cpp
@@ -1,0 +1,62 @@
+#include <Geode/Geode.hpp>
+#include <Geode/modify/CCScale9Sprite.hpp>
+#include "../TextAreaExt.hpp"
+#include <Geode/utils/web.hpp>
+
+using namespace geode::prelude;
+
+class OWCommentCell : public CCScale9Sprite {};
+
+float calculateScale(int length, int minLength, int maxLength, float minScale, float maxScale) {
+    if (length <= minLength) {
+        return minScale;
+    } else if (length >= maxLength) {
+        return maxScale;
+    } else {
+        float scale = minScale - ((length - minLength) * (minScale - maxScale) / (maxLength - minLength));
+        return scale;
+    }
+}
+
+class $modify (CCScale9Sprite)
+{
+    virtual bool init()
+    {
+        if (!CCScale9Sprite::init())
+            return false;
+
+        if (auto cell = typeinfo_cast<OWCommentCell*>(this))
+        {
+            Loader::get()->queueInMainThread([cell, this]{
+                if (this->getID() == "firee.object-workshop/comment/cell")
+                {
+                    if (auto txt = typeinfo_cast<TextArea*>(this->getChildByIDRecursive("firee.object-workshop/comment/area")))
+                    {
+                        if (auto label = typeinfo_cast<CCLabelBMFont*>(this->getChildByIDRecursive("firee.object-workshop/comment/content")))
+                        {
+                            txt->setVisible(false);
+
+                            auto area = TextAreaExt::create(label->getString(), "chatFont.fnt");
+
+                            if (area)
+                            {
+                                area->setID("comment-text-area"_spr);
+                                area->verticalAlignment = CCVerticalTextAlignment::kCCVerticalTextAlignmentCenter;
+                                area->setPosition(txt->getPosition() + ccp(0, -9));
+                                area->setAnchorPoint(ccp(0, 0.5f));
+                                area->setContentSize(txt->getContentSize());
+                                area->setScale(calculateScale(strlen(label->getString()), 16, 100, 0.65F, 0.5F));
+                                area->setLineHeight(calculateScale(strlen(label->getString()), 16, 100, 40.F, 25.F));
+                                area->setColor(label->getColor());
+
+                                this->addChild(area);
+                            }
+                        }
+                    }
+                }
+            });
+        }
+
+        return true;
+    }
+};

--- a/src/Hooks/OWCommentPopup.cpp
+++ b/src/Hooks/OWCommentPopup.cpp
@@ -1,0 +1,42 @@
+#include <Geode/Geode.hpp>
+#include <Geode/modify/FLAlertLayer.hpp>
+#include "../EmojiPickPopup.hpp"
+
+using namespace geode::prelude;
+
+class CommentPopup : public geode::Popup<> {};
+
+class $modify (CommentPopupExt, FLAlertLayer)
+{
+    struct Fields {
+        CCTextInputNode* inp = nullptr;
+    };
+
+    virtual void show()
+    {
+        FLAlertLayer::show();
+        if (typeinfo_cast<CommentPopup*>(this) && this->getID() == "firee.object-workshop/CommentPopup")
+        {
+            if (auto menu = getChildOfType<CCMenu>(m_mainLayer, 0))
+            {
+                m_fields->inp = getChildOfType<CCTextInputNode>(menu, 0);
+                auto spr = CCSprite::createWithSpriteFrameName("emoji-icon-thicker.png"_spr);
+                spr->setScale(0.8f);
+                spr->setOpacity(100);
+
+                auto btn = CCMenuItemSpriteExtra::create(spr, this, menu_selector(CommentPopupExt::onEmojis));
+                menu->addChildAtPosition(btn, Anchor::BottomRight, {-25, 25});
+            }
+        }
+    }
+
+    void onEmojis(CCObject*)
+    {
+        if (m_fields->inp)
+        {
+            m_fields->inp->onClickTrackNode(false);
+            EmojiPickPopup::create(m_fields->inp, m_fields->inp)->show();
+        }
+    }
+
+};


### PR DESCRIPTION
This PR adds support for emojis in comments for Object Workshop, since that mod has comments.

Screenshots:
![image](https://github.com/user-attachments/assets/cae0bafd-95a2-4875-85d8-47f32095b74c)
![image](https://github.com/user-attachments/assets/7119d221-c204-42a0-9e78-299d6949c391)
![image](https://github.com/user-attachments/assets/731a0cf0-bc6c-4899-acc9-064e8d98a524)

---
Additionally, I also added some additions in case you create any more files or other, such as automatically adding all sources, updating the supported geode version to be up to date (3.7.1), fixed tabbing, etc

Also I increased the mod version to v1.1.1, though you can change that to be v1.2.0 if you find it to be a major update.